### PR TITLE
update percent-encoding and use correct set of characters for encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ repository = "https://github.com/portstrom/google_translate_tts"
 version = "0.1.2"
 
 [dependencies]
-percent-encoding = "1"
+percent-encoding = "2"

--- a/readme.md
+++ b/readme.md
@@ -14,5 +14,5 @@ The URL format may change at any time. This crate may not work in the future.
 
 ```rust
 let url = google_translate_tts::url("Hello, World!", "en");
-assert_eq!(url, "https://translate.google.com/translate_tts?ie=UTF-8&q=Hello, World!&tl=en&tk=418730.60457&client=webapp");
+assert_eq!(url, "https://translate.google.com/translate_tts?ie=UTF-8&q=Hello%2C%20World!&tl=en&tk=418730.60457&client=webapp");
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```
 //! let url = google_translate_tts::url("Hello, World!", "en");
-//! assert_eq!(url, "https://translate.google.com/translate_tts?ie=UTF-8&q=Hello, World!&tl=en&tk=418730.60457&client=webapp");
+//! assert_eq!(url, "https://translate.google.com/translate_tts?ie=UTF-8&q=Hello%2C%20World%21&tl=en&tk=418730.60457&client=webapp");
 //! ```
 
 #![deny(missing_docs)]
@@ -52,7 +52,7 @@ fn compute_checksum(term: &str) -> (u32, u32) {
 ///
 /// ```
 /// let url = google_translate_tts::url("Hello, World!", "en");
-/// assert_eq!(url, "https://translate.google.com/translate_tts?ie=UTF-8&q=Hello, World!&tl=en&tk=418730.60457&client=webapp");
+/// assert_eq!(url, "https://translate.google.com/translate_tts?ie=UTF-8&q=Hello%2C%20World%21&tl=en&tk=418730.60457&client=webapp");
 /// ```
 #[must_use]
 pub fn url(term: &str, language: &str) -> String {
@@ -72,7 +72,7 @@ pub fn url(term: &str, language: &str) -> String {
 ///
 /// ```
 /// let url = google_translate_tts::url_with_speed("Hello, World!", "en", 0.24);
-/// assert_eq!(url, "https://translate.google.com/translate_tts?ie=UTF-8&q=Hello, World!&tl=en&tk=418730.60457&client=webapp&ttsspeed=0.24");
+/// assert_eq!(url, "https://translate.google.com/translate_tts?ie=UTF-8&q=Hello%2C%20World%21&tl=en&tk=418730.60457&client=webapp&ttsspeed=0.24");
 /// ```
 #[must_use]
 pub fn url_with_speed(term: &str, language: &str, speed: f32) -> String {
@@ -91,7 +91,7 @@ pub fn url_with_speed(term: &str, language: &str, speed: f32) -> String {
 fn test1() {
     assert_eq!(
         url("Добрый день!", "ru"),
-        "https://translate.google.com/translate_tts?ie=UTF-8&q=%D0%94%D0%BE%D0%B1%D1%80%D1%8B%D0%B9 %D0%B4%D0%B5%D0%BD%D1%8C!&tl=ru&tk=33233.396882&client=webapp"
+        "https://translate.google.com/translate_tts?ie=UTF-8&q=%D0%94%D0%BE%D0%B1%D1%80%D1%8B%D0%B9%20%D0%B4%D0%B5%D0%BD%D1%8C%21&tl=ru&tk=33233.396882&client=webapp"
     );
 }
 
@@ -99,7 +99,7 @@ fn test1() {
 fn test2() {
     assert_eq!(
         url_with_speed("Добрый день!", "ru", 0.24),
-        "https://translate.google.com/translate_tts?ie=UTF-8&q=%D0%94%D0%BE%D0%B1%D1%80%D1%8B%D0%B9 %D0%B4%D0%B5%D0%BD%D1%8C!&tl=ru&tk=33233.396882&client=webapp&ttsspeed=0.24"
+        "https://translate.google.com/translate_tts?ie=UTF-8&q=%D0%94%D0%BE%D0%B1%D1%80%D1%8B%D0%B9%20%D0%B4%D0%B5%D0%BD%D1%8C%21&tl=ru&tk=33233.396882&client=webapp&ttsspeed=0.24"
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,13 +21,15 @@
 
 #![deny(missing_docs)]
 
-mod encode_set {
-    use percent_encoding::define_encode_set;
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC};
 
-    define_encode_set! {
-        pub ENCODE_SET = [percent_encoding::SIMPLE_ENCODE_SET] | {'&'}
-    }
-}
+// https://en.wikipedia.org/wiki/Percent-encoding#Types_of_URI_characters
+// unreserved characters are 'a..zA..Z-_.~'
+const ENCODE_SET: &'static AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
 
 fn compute_checksum(term: &str) -> (u32, u32) {
     let mut checksum: u32 = 429955;
@@ -57,7 +59,7 @@ pub fn url(term: &str, language: &str) -> String {
     let checksum = compute_checksum(term);
     format!(
         "https://translate.google.com/translate_tts?ie=UTF-8&q={}&tl={}&tk={}.{}&client=webapp",
-        percent_encoding::utf8_percent_encode(term, encode_set::ENCODE_SET),
+        percent_encoding::utf8_percent_encode(term, ENCODE_SET),
         language,
         checksum.0,
         checksum.1
@@ -77,7 +79,7 @@ pub fn url_with_speed(term: &str, language: &str, speed: f32) -> String {
     let checksum = compute_checksum(term);
     format!(
         "https://translate.google.com/translate_tts?ie=UTF-8&q={}&tl={}&tk={}.{}&client=webapp&ttsspeed={}",
-        percent_encoding::utf8_percent_encode(term, encode_set::ENCODE_SET),
+        percent_encoding::utf8_percent_encode(term, ENCODE_SET),
         language,
         checksum.0,
         checksum.1,


### PR DESCRIPTION
This is the set of unreserved characters in a URL:

A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
a | b | c | d | e | f | g | h | i | j | k | l | m | n | o | p | q | r | s | t | u | v | w | x | y | z
0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | - | _ | . | ~ | 

expressed in rust as 
```rust
const ENCODE_SET: &'static AsciiSet = &NON_ALPHANUMERIC
    .remove(b'-')
    .remove(b'_')
    .remove(b'.')
    .remove(b'~');
```